### PR TITLE
Fix CI workflow to trigger on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'  # Run workflow on version tags
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Issue
The CI workflow currently doesn't run when version tags are pushed or GitHub releases are created, which prevents automatic PyPI publishing.

## Changes
- Added tag event triggers to the CI workflow configuration
- Specifically configured to run on tags starting with 'v' (e.g., v0.1.0)

## Testing
Once merged, this will enable the automated release pipeline to:
1. Run tests when a version tag is pushed
2. Build and publish the package to PyPI upon successful tests
3. Work seamlessly with GitHub releases

This is a prerequisite for completing the initial v0.1.0 release on PyPI.